### PR TITLE
fix: added watcher-handler for triggered animations programmatically

### DIFF
--- a/packages/src/BaseButton.js
+++ b/packages/src/BaseButton.js
@@ -50,6 +50,13 @@ export const BaseButton = {
       this.currentActive = !this.currentActive;
     },
   },
+  watch: {
+    active: {
+      handler(val) {
+        this.currentActive = val;
+      },
+    },
+  },
 };
 
 export const IconMixin = {


### PR DESCRIPTION
## Issue
- Animations aren't triggered when the `active` change.

## Solution
- Added handler in `active` state for trigger animation.

Fixed by #3 